### PR TITLE
Change Event Handling methods, other fixes

### DIFF
--- a/other/vst2_lglw_debug_plugin/plugin.cpp
+++ b/other/vst2_lglw_debug_plugin/plugin.cpp
@@ -496,8 +496,8 @@ VstIntPtr VSTPluginDispatcher(VSTPlugin *vstPlugin, VstInt32 opCode, VstInt32 in
 #ifdef USE_LGLW
          if(lglw_window_is_visible(wrapper->lglw))
          {
-            // lglw_events(wrapper->lglw);
             // wrapper->redrawWindow();  // redraw is triggered by timer_cbk instead
+            lglw_events(wrapper->lglw);
          }
 #endif // USE_LGLW
          break;
@@ -683,7 +683,7 @@ VST_EXPORT VSTPlugin *VSTPluginMain(VSTHostCallback vstHostCallback)
    // simply create our plugin C++ class
    VSTPluginWrapper *plugin =
       new VSTPluginWrapper(vstHostCallback,
-                           //CCONST('u', 's', 'a', '§'), // registered with Steinberg (http://service.steinberg.de/databases/plugin.nsf/plugIn?openForm)
+                           //CCONST('u', 's', 'a', 'ï¿½'), // registered with Steinberg (http://service.steinberg.de/databases/plugin.nsf/plugIn?openForm)
                            CCONST('t', 'e', 's', 't'), // unregistered
                            PLUGIN_VERSION, // version
                            0,    // no params

--- a/src/vst2_main.cpp
+++ b/src/vst2_main.cpp
@@ -1117,6 +1117,15 @@ public:
       }
    }
 
+   void events(void) {
+      setGlobals();
+
+      if(lglw_window_is_visible(rack::global_ui->window.lglw))
+      {
+         lglw_events(rack::global_ui->window.lglw);
+      }
+   }
+
 private:
    // the host callback (a function pointer)
    VSTHostCallback _vstHostCallback;
@@ -1798,9 +1807,10 @@ VstIntPtr VSTPluginDispatcher(VSTPlugin *vstPlugin,
 #endif
 
       case effEditIdle:
-         if(0 == wrapper->redraw_ival_ms)
+         // if(0 == wrapper->redraw_ival_ms)
          {
             wrapper->queueRedraw();
+            wrapper->events();
          }
          break;
 


### PR DESCRIPTION
Run lglw_events in effEditIdle (debug plugin)
Run lglw_events in effEditIdle (VSR plugin)
Run effEditIdle loop in debug host if no _XEventProc
Temporarily swap lglw_log for printf (needs fixing)
Suppress most mouse event messages
Bring back sending of child events to parent (rare occurence)
Cleanup some lglw_window_open code
lglw_window_open event mask setup to receive events for itself
Comment the setting of _XEventProc (to get to effEditIdle loop)
NoEventMask on mouse grabbing, possible fix for grabbing issues
Setup working and non-blocking lglw_events