### PR TITLE
Implement Vst Version Callback

### DIFF
--- a/src/vst2_main.cpp
+++ b/src/vst2_main.cpp
@@ -1594,6 +1594,10 @@ VstIntPtr VSTPluginDispatcher(VSTPlugin *vstPlugin,
          // request for the version
          return PLUGIN_VERSION;
 
+      case effGetVstVersion:
+          r = kVstVersion;
+          break;
+
       case effGetEffectName:
 #ifdef VST2_EFFECT
          ::strncpy((char*)ptr, "VeeSeeVST Rack 0.6.1", kVstMaxEffectNameLen);


### PR DESCRIPTION
Some hosts check the VST-standard version of plugins.
This fixes MIDI Ports, which are only available in VST 2.x, for some hosts (Ardour 5.x in particular)